### PR TITLE
Fix UserData Error: remove redundant JsonProperty.

### DIFF
--- a/Squidex.Identity/Model/UserData.cs
+++ b/Squidex.Identity/Model/UserData.cs
@@ -66,7 +66,6 @@ namespace Squidex.Identity.Model
         public Dictionary<string, string> Tokens { get; set; }
 
         [JsonConverter(typeof(InvariantConverter))]
-        [JsonProperty("logins")]
         public List<UserLogin> LoginVals { get; set; }
 
         public void EnsureLogins()


### PR DESCRIPTION
Fix the error messages after login or register with squidex-identity.